### PR TITLE
FIX: AFTER -> FOR in Large_Crewed_Lab_6

### DIFF
--- a/GameData/ScienceLabInfo/Parts/Large_Crewed_Lab_6.cfg
+++ b/GameData/ScienceLabInfo/Parts/Large_Crewed_Lab_6.cfg
@@ -1,4 +1,4 @@
-+PART[Large_Crewed_Lab]:AFTER[ScienceLabInfo]
++PART[Large_Crewed_Lab]:FOR[ScienceLabInfo]
 {
 	@name        = Large_Crewed_Lab_6
 	@title       = #SLI_Large_Crewed_Lab_6_title


### PR DESCRIPTION
Change the `AFTER` to `FOR` in `Large_Crewed_Lab_6`. Recently ran into an issue making a patch for this mod where `Large_Crewed_Lab_6` was hard to access since it was created after the ScienceLabInfo pass, not during it.